### PR TITLE
Fix YAML.load_file with Ruby 3.1 or higher

### DIFF
--- a/lib/active_admin_menu/config.rb
+++ b/lib/active_admin_menu/config.rb
@@ -22,11 +22,18 @@ module ActiveAdminMenu
     end
 
     def source=(value)
-      @source = value.is_a?(Hash) ? value : YAML.load_file(value.to_s)
+      @source = value.is_a?(Hash) ? value : load_yaml_file(value)
     end
 
     def namespaced_source
       source[namespace] || source
+    end
+
+    private
+
+    def load_yaml_file(file_name)
+      text = File.read(file_name)
+      YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(text) : YAML.load(text)
     end
   end
 end


### PR DESCRIPTION
### Background

close #5

### Detail

I can solve this by using `YAML.unsafe_load`.